### PR TITLE
Add relation to sphinx

### DIFF
--- a/sphinx-survey.yml
+++ b/sphinx-survey.yml
@@ -16,6 +16,14 @@ questions:
     description: "First, we'd like to know about how you work and what tools you use."
     type: statement
 
+  - title: 'What is your relation to the Sphinx project?'
+    multiple: true
+    choices:
+      - 'User'
+      - 'Extension author'
+      - 'Theme author'
+      - 'Contributor'
+      
   - title: 'Which of the following roles is closest to your job?'
     other: true
     choices:


### PR DESCRIPTION
From: https://github.com/orgs/sphinx-doc/discussions/13331#discussioncomment-12310597

While the groups other than users are comparably small, I anticipate that they will take part overproportionally in the survey because the are more involved with the project, and they may have significantly different perspectives and answers compared to users. It therefore may be helpful to be able to filter on this when evaluating the survey.